### PR TITLE
[WIP] Update URL to match value from Mesosphere docs

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ end
 # DCOS from 'testing' and this URL might change in the future.
 # https://s3.amazonaws.com/downloads.mesosphere.io/dcos/stable/dcos_generate_config.sh
 remote_file '/root/dcos_generate_config.sh' do
-  source 'https://downloads.mesosphere.io/dcos/testing/continuous/dcos_generate_config.sh'
+  source 'https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh'
   mode '0755'
 end
 


### PR DESCRIPTION
Mesosphere docs have the DCOS installer shell script at a different location than in this cookbook. See https://dcos.io/docs/1.7/administration/installing/custom/cli/
