### PR TITLE
Correction to Attribute Value for Public Slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The behavior of this cookbook is managed by attributes documented in the [attrib
 Roles
 ----------
 
-You can create a Chef Role and apply it to nodes as necessary to specify `master`, `slave` and `slave-public` as appropriate. Any additional configuration should probably be set as override attributes in an Environment to ensure all nodes receive those global settings.
+You can create a Chef Role and apply it to nodes as necessary to specify `master`, `slave` and `slave_public` as appropriate. Any additional configuration should probably be set as override attributes in an Environment to ensure all nodes receive those global settings.
 
 ### Example Role dcos_master.rb ###
 ````ruby


### PR DESCRIPTION
Correcting attribute value for a public slave. Setting node['dcos']['dcos_role'] to 'slave-public' results in an error, in which the installer script suggests "master", "slave" or "slave_public". Setting an attribute of "slave_public" does seem to correct the problem and result in the install and configuration as expected.
