### PR TITLE
Update cookbook to modern standards

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,25 @@
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+platforms:
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+
+suites:
+  - name: default
+    run_list:
+      - recipe[dcos::default]
+    attributes:
+      dcos:
+        master_list: ['127.0.0.1']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,37 @@
-language: ruby
-sudo: false
+sudo: required
+dist: trusty
 
 addons:
   apt:
     sources:
-      - chef-current-precise
+      - chef-current-trusty
     packages:
       - chefdk
 
-# Ensure we make ChefDK's Ruby the default
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
+
+branches:
+  only:
+    - master
+
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-centos-7
+
 before_script:
-  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-script:
-  - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/rubocop --version
-  - /opt/chefdk/embedded/bin/rubocop
-  - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
-  - /opt/chefdk/embedded/bin/rspec --version
-  - /opt/chefdk/embedded/bin/rspec
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - eval "$(chef shell-init bash)"
+  - chef --version
+  - cookstyle --version
+  - foodcritic --version
+
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
+
+matrix:
+  include:
+    - script:
+      - chef exec delivery local all
+      env: UNIT_AND_LINT=1

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'dcos'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'partnereng@chef.io'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs/Configures Mesosphere'
 long_description 'Installs/Configures Mesosphere'
 version '0.3.0'
@@ -10,6 +10,8 @@ source_url 'https://github.com/chef-partners/dcos-cookbook' if
   respond_to?(:source_url)
 issues_url 'https://github.com/chef-partners/dcos-cookbook/issues' if
   respond_to?(:issues_url)
+chef_version '>= 11' if
+  respond_to?(:chef_version)
 
 supports 'centos'
 supports 'oracle'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,11 +38,12 @@ docker_service 'default' do
   action [:create, :start]
 end
 
-if node['dcos']['dcos_earlyaccess'] = true
-  location = 'https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh'
-else
-  location = 'https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh'
-end
+location =
+  if node['dcos']['dcos_earlyaccess'] == true
+    'https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh'
+  else
+    'https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh'
+  end
 
 # Note this link does not have versioning, so using it will always be the latest
 # DCOS from https://dcos.io/docs/1.7/administration/installing/local/

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,8 +15,8 @@ describe 'dcos::default' do
               {
                 'family' => 'inet',
                 'netmask' => '255.255.255.0',
-                'broadcast' => '192.168.1.255'
-              }
+                'broadcast' => '192.168.1.255',
+              },
           }
       end.converge(described_recipe)
     end


### PR DESCRIPTION
Updated several items to improve the cookbook.

- Use Delivery for testing
- Use Kitchen Dokken on Ubuntu 16.04 in Travis CI
- Update metadata to include missing items/update license string
- Cleanup invalid syntax in default recipe

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>