### PR TITLE
Fix inclusion of chef-yum-docker condition

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ package %w(
 
 group 'nogroup'
 
-include_recipe 'chef-yum-docker' if node['dcos']['docker_version']
+include_recipe 'chef-yum-docker' if node['dcos']['manage_docker']
 
 # Install docker with overlayfs
 docker_service 'default' do


### PR DESCRIPTION
The include_recipe 'chef-yum-docker' guarding conditional should
have been `node['dcos']['manager_docker']` rather than checking
`node['dcos']['docker_version']` existence.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>