### PR TITLE
Support DC/OS Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Description
 ===========
 
-Manage deployment and configuration of underlying Mesosphere DC/OS installation.
+Manage deployment and configuration of underlying Mesosphere DC/OS installation. This cookbook supports both DC/OS
+OSS installations (default) and DC/OS Enterprise.
 
 Requirements
 ------------
@@ -19,8 +20,10 @@ The `node['dcos']['dcos_role']` attribute controls the DC/OS role to apply to th
 `static` to specify the list of DC/OS master node IPv4 addresses to connect at startup (this must be an odd number
 of masters and cannot be changed, later).
 
-This cookbook uses the EarlyAccess channel, by default. Setting `node['dcos']['dcos_version']` to `stable` will
-install the latest stable version of DC/OS (currently `1.9.3`).
+This cookbook uses the stable channel, by default. Setting `node['dcos']['dcos_version']` to `earlyaccess` will
+install the latest EarlyAccess version of DC/OS OSS. Enterprise support can be enabled by setting
+`node['dcos']['dcos_enterprise']` to `true` and providing a license key in `node['dcos']['dcos_license_text']`
+via whichever manner you prefer.
 
 Roles
 ----------
@@ -75,7 +78,7 @@ There is basic coverage for the default recipe.
 
 InSpec
 ------
-TBD
+There is basic functional testing of the DC/OS OSS setup for a single master node.
 
 Test Kitchen
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: dcos
 #
 # Copyright 2016 Chef Software, Inc
-# Copyright 2017 Chris Gianelloni
+# Copyright 2017-2018 Chris Gianelloni
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,18 +18,33 @@
 # limitations under the License.
 #
 
-default['dcos']['dcos_earlyaccess'] = true
+# DC/OS Edition/Version Setup
+default['dcos']['dcos_earlyaccess'] = false
 default['dcos']['dcos_version'] = node['dcos']['dcos_earlyaccess'] ? 'earlyaccess' : 'stable'
+default['dcos']['dcos_enterprise'] = false
+
+# DC/OS role
 default['dcos']['dcos_role'] = 'master' # 'master', 'slave' or 'slave_public'
 
+# DC/OS license (Enterprise only, 1.11+)
+default['dcos']['dcos_license_text'] = nil
+
+# DC/OS config.yaml
 default['dcos']['config']['bootstrap_url'] = 'file:///usr/src/dcos/genconf/serve'
 default['dcos']['config']['cluster_name'] = 'DCOS'
 default['dcos']['config']['exhibitor_storage_backend'] = 'static'
+default['dcos']['config']['ip_detect_public_filename'] = 'genconf/ip-detect-public'
 default['dcos']['config']['master_discovery'] = 'static'
 # ipv4 only, must be odd number 1-9
 default['dcos']['config']['master_list'] = []
 # upstream DNS for MesosDNS
 default['dcos']['config']['resolvers'] = ['8.8.8.8', '8.8.4.4']
+default['dcos']['config']['security'] = 'permissive' if node['dcos']['dcos_enterprise']
+default['dcos']['config']['superuser_username'] = 'dcos' if node['dcos']['dcos_enterprise']
+# WARNING: this password is 'dcos', CHANGE IT!
+default['dcos']['config']['superuser_password_hash'] =
+  '$6$rounds=656000$jebZ9.mHzOGexfOq$NEpBlsUot6mGe3ExpfOGioRY02.WEFYlZCIeTDtq7d648FI4oyPt07w8tgNVub0PNVxRT0am9NbWDiYCHYkM9.' \
+  if node['dcos']['dcos_enterprise']
 
 default['dcos']['manage_docker'] = true
 default['dcos']['docker_storage_driver'] = 'overlay'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,6 +2,7 @@ module Dcos
   module Helpers
     def dcos_generate_config_url
       return node['dcos']['dcos_generate_config_url'] if node['dcos'].key?('dcos_generate_config_url')
+      return "#{dcos_base_url}/dcos_generate_config.ee.sh" if dcos_enterprise?
       case node['dcos']['dcos_version']
       when 'EarlyAccess', 'earlyaccess'
         "#{dcos_base_url}/dcos_generate_config.sh"
@@ -10,22 +11,46 @@ module Dcos
       end
     end
 
+    def dcos_enterprise?
+      node['dcos']['dcos_enterprise']
+    end
+
     private
 
     def dcos_base_url
       case node['dcos']['dcos_version']
-      when '1.10.4', '1.10.2', '1.10.1', '1.10.0', '1.9.7', '1.9.6', '1.9.5', '1.9.4', '1.9.3', '1.9.2', '1.9.1', '1.8.9'
-        "https://downloads.dcos.io/dcos/stable/#{node['dcos']['dcos_version']}"
+      when
+        '1.11.0',
+        '1.10.5',
+        '1.10.4',
+        '1.10.2',
+        '1.10.1',
+        '1.10.0',
+        '1.9.7',
+        '1.9.6',
+        '1.9.5',
+        '1.9.4',
+        '1.9.3',
+        '1.9.2',
+        '1.9.1',
+        '1.8.9'
+        return "https://downloads.mesosphere.com/dcos-enterprise/stable/#{node['dcos']['dcos_version']}" if dcos_enterprise?
+        return "https://downloads.dcos.io/dcos/stable/#{node['dcos']['dcos_version']}"
       when 'EarlyAccess', 'earlyaccess'
         'https://downloads.dcos.io/dcos/EarlyAccess'
       else # stable or older releases
+        return 'https://downloads.mesosphere.com/dcos-enterprise/stable/1.11.0' if dcos_enterprise?
         'https://downloads.dcos.io/dcos/stable'
       end
     end
 
     def dcos_commit_id
       case node['dcos']['dcos_version']
-      when 'stable', '1.10.4'
+      when 'stable', '1.11.0'
+        'b6d6ad4722600877fde2860122f870031d109da3'
+      when '1.10.5'
+        '5831285e56a88d3f54446a987a0384f915832f40'
+      when '1.10.4'
         '2d45a8f9e277a60007f277f70f01d076c913a7fe'
       when '1.10.2'
         '12b494a3309c65a22b7d5553debd1c053e008a31'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
-name 'dcos'
-maintainer 'Chef Software, Inc.'
+name             'dcos'
+maintainer       'Chef Software, Inc.'
 maintainer_email 'partnereng@chef.io'
-license 'Apache-2.0'
-version '1.1.0'
-description 'Installs/Configures Mesosphere DC/OS'
+license          'Apache-2.0'
+description      'Installs/Configures Mesosphere DC/OS'
 long_description 'Installs/Configures Mesosphere DC/OS'
+version          '1.2.0'
 
 source_url 'https://github.com/chef-partners/dcos-cookbook' if
   respond_to?(:source_url)


### PR DESCRIPTION
Updated helper methods to support the latest release of DC/OS OSS
1.10 and also added support for DC/OS OSS 1.11.0. Added support
for DC/OS Enterprise. It's still up to the user to provide a
license. Fixed the condition around including the
`chef-yum-docker::default` recipe to properly use the
`node['dcos']['manage_docker']` attribute value.

This replaces #11 and #12 