### PR TITLE
Remove zookeeper Gem requirements

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,7 +13,7 @@ module Dcos
     end
 
     def dcos_enterprise?
-      node['dcos']['dcos_enterprise']
+      node['dcos']['dcos_enterprise'].to_s == 'true'
     end
 
     private

--- a/resources/dcos_user.rb
+++ b/resources/dcos_user.rb
@@ -25,11 +25,9 @@ property :zk_host, String,
          required: true
 property :email, String, required: false
 
-require 'zookeeper'
-
-include Zookeeper::Constants
-
 load_current_value do
+  require 'zookeeper'
+  include Zookeeper::Constants
   z = Zookeeper.new(zk_host)
   user_node = z.get(path: "/dcos/users/#{email}")
   email user_node[:data] if user_node[:rc] == ZOK
@@ -38,6 +36,8 @@ end
 action :create do
   # If there is a change, remove and replace the current data
   converge_if_changed :email do
+    require 'zookeeper'
+    include Zookeeper::Constants
     z = Zookeeper.new(zk_host)
     z.delete(path: "/dcos/users/#{email}") # Fails cleanly if it doesn't exist.
     z.create(path: "/dcos/users/#{email}", data: email)
@@ -45,6 +45,8 @@ action :create do
 end
 
 action :delete do
+  require 'zookeeper'
+  include Zookeeper::Constants
   # Remove the user node from Zookeeper
   z = Zookeeper.new(zk_host)
   z.delete(path: "/dcos/users/#{email}")


### PR DESCRIPTION
Move the `require 'zookeeper'` blocks inside the resources that
use them versus the global scope. Also, support strings instead of
just booleans in `dcos_enterprise?` helper.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>