### PR TITLE
Create a preflight-check execute block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ addons:
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
 
-branches:
-  only:
-    - master
+# Comment this, so we test everything, all the time
+# branches:
+#   only:
+#     - master
 
 services: docker
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -95,6 +95,15 @@ file '/usr/src/dcos/genconf/serve/dcos_install.sh' do
   mode '0755'
 end
 
+# We're going to poll this up to 30 times, to prevent issues where a port may temporarily be in use
+execute 'preflight-check' do
+  command "/usr/src/dcos/genconf/serve/dcos_install.sh --preflight-only #{node['dcos']['dcos_role']}"
+  retry_delay 1
+  retries 30
+  action :run
+  not_if { ::File.exist?('/opt/mesosphere/environment') } # assume DC/OS is installed
+end
+
 execute 'dcos_install' do
   command "/usr/src/dcos/genconf/serve/dcos_install.sh #{node['dcos']['dcos_role']}"
   creates '/opt/mesosphere/environment'


### PR DESCRIPTION
In some situations, such as spinning up new nodes in a cloud
provider, it may be necessary to let the host "settle" a bit to
reduce the number of ports in use. To work around this, we will
run the DC/OS pre-flight check in a loop with 30 retries.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>