### PR TITLE
Guard cloud fault-domain-detect script when onprem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,6 +74,7 @@ remote_file '/usr/src/dcos/genconf/fault-domain-detect' do
   source 'https://raw.githubusercontent.com/dcos/dcos/master/gen/fault-domain-detect/cloud.sh'
   mode '0755'
   only_if { dcos_enterprise? && node['dcos']['dcos_version'].to_f >= 1.11 }
+  not_if { node['dcos']['config'].key?('platform') && node['dcos']['config']['platform'] == 'onprem' }
 end
 
 remote_file '/usr/src/dcos/dcos_generate_config.sh' do


### PR DESCRIPTION
The provided fault-domain-detect script isn't suitable for onprem
installations, so don't install it.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>