### PR TITLE
Recipe for DC/OS CLI

### DIFF
--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: dcos
+# Recipe:: cli
+#
+# Copyright 2018 Chris Gianelloni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cli_base_url = "https://downloads.dcos.io/binaries/cli/#{node['os']}/#{node['kernel']['machine'].tr('_', '-')}"
+
+# Fetch the `dcos` CLI tool
+remote_file '/usr/local/bin/dcos' do
+  source "#{cli_base_url}/dcos-#{node['dcos']['dcos_version'].to_f}/dcos"
+  mode '0755'
+end

--- a/spec/unit/recipes/cli_spec.rb
+++ b/spec/unit/recipes/cli_spec.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: dcos
+# Spec:: cli
+#
+
+require 'spec_helper'
+
+describe 'dcos::cli' do
+  context 'Default behavior' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
+    end
+
+    it 'creates remote_file[/usr/local/bin/dcos]' do
+      expect(chef_run).to create_remote_file('/usr/local/bin/dcos').with(mode: '0755')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This is a simple recipe to install the `dcos` command line tool
for DC/OS to `/usr/local/bin/dcos`.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>