### PR TITLE
Helper: dcos_cluster_address

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,6 +16,18 @@ module Dcos
       node['dcos']['dcos_enterprise'].to_s == 'true'
     end
 
+    def dcos_cluster_address
+      if node['dcos'].key?('config') && node['dcos']['config'].key?('master_discovery') &&
+         node['dcos']['config']['master_discovery'] == 'master_http_loadbalancer' &&
+         node['dcos']['config'].key?('master_external_loadbalancer')
+        node['dcos']['config']['master_external_loadbalancer']
+      elsif node['dcos'].key?('config') && node['dcos']['config'].key?('master_list')
+        node['dcos']['config']['master_list'].first # yuck, we can do better
+      else
+        'leader.mesos' # assuming we're inside the cluster
+      end
+    end
+
     private
 
     def dcos_base_url


### PR DESCRIPTION
Include a new helper method to get the address to a DC/OS cluster
for sending API calls or CLI commands. Use `leader.mesos` as the
default address if we're not configured with either an external
load balancer on the masters or a configured master list. This can
be useful for cases where you may want to install local tools to
run against a remote cluster.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>