### PR TITLE
Updates from session w/ Justin Lee

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Description
 Manage deployment and configuration of underlying Mesosphere DC/OS installation. This cookbook supports both DC/OS
 OSS installations (default) and DC/OS Enterprise.
 
+Note: The default username and password for DC/OS Enterprise is `bootstrapuser`/`deleteme` and can be changed by setting
+`node['dcos']['config']['superuser_username']` and `node['dcos']['config']['superuser_password_hash']`, respectively.
+
 Requirements
 ------------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,18 +33,12 @@ default['dcos']['dcos_license_text'] = nil
 default['dcos']['config']['bootstrap_url'] = 'file:///usr/src/dcos/genconf/serve'
 default['dcos']['config']['cluster_name'] = 'DCOS'
 default['dcos']['config']['exhibitor_storage_backend'] = 'static'
-default['dcos']['config']['ip_detect_public_filename'] = 'genconf/ip-detect-public'
 default['dcos']['config']['master_discovery'] = 'static'
 # ipv4 only, must be odd number 1-9
 default['dcos']['config']['master_list'] = []
 # upstream DNS for MesosDNS
 default['dcos']['config']['resolvers'] = ['8.8.8.8', '8.8.4.4']
 default['dcos']['config']['security'] = 'permissive' if node['dcos']['dcos_enterprise']
-default['dcos']['config']['superuser_username'] = 'dcos' if node['dcos']['dcos_enterprise']
-# WARNING: this password is 'dcos', CHANGE IT!
-default['dcos']['config']['superuser_password_hash'] =
-  '$6$rounds=656000$jebZ9.mHzOGexfOq$NEpBlsUot6mGe3ExpfOGioRY02.WEFYlZCIeTDtq7d648FI4oyPt07w8tgNVub0PNVxRT0am9NbWDiYCHYkM9.' \
-  if node['dcos']['dcos_enterprise']
 
 default['dcos']['manage_docker'] = true
 default['dcos']['docker_storage_driver'] = 'overlay'
@@ -58,3 +52,9 @@ default['dcos']['leader_check_retries'] = 120
 # otherwise use 'eth0', 'eth1', etc. and it will get the ipaddress associated
 # with node['network']['interface'][VALUE]
 default['dcos']['ip-detect'] = 'eth0'
+
+# Override this to use a file from another cookbook
+default['dcos']['ip-detect-public']['cookbook'] = 'dcos'
+default['dcos']['ip-detect-public']['source'] = 'ip-detect-public'
+default['dcos']['fault-domain-detect']['cookbook'] = 'dcos'
+default['dcos']['fault-domain-detect']['source'] = 'fault-domain-detect'

--- a/files/default/fault-domain-detect
+++ b/files/default/fault-domain-detect
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+AWS_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
+
+AZURE_REGION_URL="http://169.254.169.254/metadata/instance/compute/location?api-version=2017-08-01&format=text"
+AZURE_FD_URL="http://169.254.169.254/metadata/instance/compute/platformFaultDomain?api-version=2017-04-02&format=text"
+
+GCP_METADATA_URL="http://metadata.google.internal/computeMetadata/v1/instance/zone"
+
+
+function aws() {
+    METADATA="$(curl -f -m3 $AWS_URL 2>/dev/null)"
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "unable to fetch aws region/zone. URL $AWS_URL. Ret code $rc" >&2
+        exit 1
+    fi
+    REGION=$(echo $METADATA | grep -Po "\"region\"\s+:\s+\"(.*?)\"" | cut -f2 -d: | tr -d ' \"')
+    ZONE=$(echo $METADATA | grep -Po "\"availabilityZone\"\s+:\s+\"(.*?)\"" | cut -f2 -d: | tr -d ' \"')
+    echo "{\"fault_domain\":{\"region\":{\"name\": \"aws/$REGION\"},\"zone\":{\"name\": \"aws/$ZONE\"}}}"
+}
+
+function azure() {
+    REGION=$(curl -f -m3 -H Metadata:true "$AZURE_REGION_URL" 2>/dev/null)
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "unable to fetch azure region. URL $AZURE_REGION_URL. Ret code $rc" >&2
+      exit 1
+    fi
+
+    FAULT_DOMAIN=$(curl -f -m3 -H Metadata:true "$AZURE_FD_URL" 2>/dev/null)
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "unable to fetch azure fault domain. URL $AZURE_FD_URL. Ret code $rc" >&2
+      exit 1
+    fi
+
+    echo "{\"fault_domain\":{\"region\":{\"name\": \"azure/$REGION\"},\"zone\":{\"name\": \"azure/$FAULT_DOMAIN\"}}}"
+}
+
+function gcp() {
+    BODY=$(curl -f -m3 -H "Metadata-Flavor: Google" "$GCP_METADATA_URL" 2>/dev/null)
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "unable to fetch gcp metadata. URL $GCP_METADATA_URL. Ret code $rc" >&2
+      exit 1
+    fi
+
+    ZONE=$(echo "$BODY" | sed 's@^projects/.*/zones/\(.*\)$@\1@')
+    REGION=$(echo "$ZONE" | sed 's@\(.*-.*\)-.*@\1@')
+
+    echo "{\"fault_domain\":{\"region\":{\"name\": \"gcp/$REGION\"},\"zone\":{\"name\": \"gcp/$ZONE\"}}}"
+}
+
+function main() {
+    if [ $# -eq 1 ]; then
+        case $1 in
+            --aws) aws; exit 0;;
+            --azure) azure; exit 0;;
+            --gcp) gcp; exit 0;;
+        esac
+        echo "invalid parameter $1. Must be one of --aws, --azure or --gcp"
+        exit 1
+    fi
+
+    # declare PROVIDERS as an empty array
+    PROVIDERS=()
+
+    # try aws first
+    curl -f -q -m1 "$AWS_URL" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        PROVIDERS+=("aws")
+    fi
+
+    # try azure
+    curl -f -q -m1 -H 'Metadata:true' "$AZURE_REGION_URL" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        PROVIDERS+=("azure")
+    fi
+
+    # try gcp
+    curl -f -q m1 -H "Metadata-Flavor: Google" "$GCP_METADATA_URL" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        PROVIDERS+=("gcp")
+    fi
+
+    if [ ${#PROVIDERS[@]} -eq 0 ]; then
+        "ERROR: unable to detect cloud provider. Use explicit parameter --aws, --azure, or --gcp" >&2
+        exit 1
+    fi
+
+    if [ ${#PROVIDERS[@]} -gt 1 ]; then
+        echo "ERROR: found multiple cloud providers: ${PROVIDERS[@]}" >&2
+        exit 1
+    fi
+
+    provider=${PROVIDERS[0]}
+    case $provider in
+        "aws") aws; exit 0;;
+        "gcp") gcp; exit 0;;
+        "azure") azure; exit 0;;
+        *) echo "ERROR: Unknown cloud provider $provider" >&2; exit 1;;
+    esac
+}
+
+main $@

--- a/recipes/_ip-detect.rb
+++ b/recipes/_ip-detect.rb
@@ -38,7 +38,8 @@ else
     variables(interface: interface)
   end
   cookbook_file '/usr/src/dcos/genconf/ip-detect-public' do
-    source 'ip-detect-public'
+    cookbook node['dcos']['ip-detect-public']['cookbook']
+    source node['dcos']['ip-detect-public']['source']
     mode '0755'
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,6 +38,10 @@ package %w(
   xz
 )
 
+# Hard-coded `ifconfig` means we have to include this
+# https://github.com/apache/mesos/blob/a741b15e889de3242e3aa7878105ab9d946f6ea2/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp#L2106
+package 'net-tools'
+
 group 'nogroup'
 
 include_recipe 'chef-yum-docker' if node['dcos']['manage_docker']
@@ -69,12 +73,12 @@ template '/usr/src/dcos/genconf/config.yaml' do
 end
 
 # Only supported on DC/OS Enterprise 1.11+
-remote_file '/usr/src/dcos/genconf/fault-domain-detect' do
+cookbook_file '/usr/src/dcos/genconf/fault-domain-detect' do
   # Pull latest from GitHub
-  source 'https://raw.githubusercontent.com/dcos/dcos/master/gen/fault-domain-detect/cloud.sh'
+  cookbook node['dcos']['fault-domain-detect']['cookbook']
+  source node['dcos']['fault-domain-detect']['source']
   mode '0755'
   only_if { dcos_enterprise? && node['dcos']['dcos_version'].to_f >= 1.11 }
-  not_if { node['dcos']['config'].key?('platform') && node['dcos']['config']['platform'] == 'onprem' }
 end
 
 remote_file '/usr/src/dcos/dcos_generate_config.sh' do

--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -1,6 +1,6 @@
 ---
 <%- @config.each do |k, v| %>
-  <%- next if %w(agent_list public_agent_list master_list resolvers rexray).include?(k) %>
+  <%- next if %w(agent_list public_agent_list master_list resolvers rexray rexray_config).include?(k) %>
 <%= k %>: '<%= v %>'
 <% end %>
 <% %w(agent_list public_agent_list master_list resolvers).each do |n| %>
@@ -11,10 +11,12 @@
     <% end %>
   <% end %>
 <% end %>
-<% unless @config['rexray'].nil? || @config['rexray'].empty? %>
-  <% require 'yaml' %>
-rexray:
-  <%- @config['rexray'].to_hash.dup.to_yaml.lines.drop(1).each do |l| %>
-  <%= l.chomp %>
+<% %w(rexray rexray_config).each do |key| %>
+  <% unless @config[key].nil? || @config[key].empty? %>
+<%= key %>:
+    <% require 'yaml' %>
+    <%- JSON.parse(@config[key].to_json).to_yaml.lines.drop(1).each do |l| %>
+    <%= l.chomp %>
+    <% end %>
   <% end %>
 <% end %>

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -71,7 +71,6 @@ end
   dcos-exhibitor
   dcos-marathon
   dcos-mesos-master
-  dcos-spartan
 ).each do |svc|
   describe service(svc) do
     it { should be_installed }
@@ -95,7 +94,6 @@ end
 end
 
 %w(
-  /etc/mesosphere/setup-flags/cluster-packages.json
   /etc/mesosphere/setup-flags/repository-url
 ).each do |conf|
   describe file(conf) do

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,6 +1,6 @@
 name: default-dcos-master
 title: Integration tests for DC/OS master with Oauth
 summary: This InSpec profile contains integration tests for DC/OS cookbook
-version: 0.0.1
+version: 0.0.2
 supports:
   - os-family: linux


### PR DESCRIPTION
This introduces a few settings and changes to the cookbook after a
Slack discussion w/ Justin Lee from Mesosphere.

- Use default DC/OS Enterprise password
- Do not configure `ip_detect_public_filename`
- Copy `cloud.sh` locally as `fault-domain-detect` script
- Allow overriding the fault-domain-detect script using attributes
- Allow overriding the ip-detect-public script using attributes
- Install `net-tools` due to an issue in Mesos
- Fix RexRay configuration for DC/OS 1.8+
- Remove version-specific integration checks

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>