### PR TITLE
Allow disabling scripts using nil source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
-gem 'chef'
-gem 'chefspec'
-gem 'inspec'
-gem 'kitchen-digitalocean'
-gem 'kitchen-docker'
-gem 'kitchen-dokken'
-gem 'kitchen-inspec'
 gem 'stove'
 gem 'zookeeper'
-
-group :lint do
-  gem 'cookstyle'
-  gem 'foodcritic'
-  gem 'rubocop'
-end

--- a/recipes/_ip-detect.rb
+++ b/recipes/_ip-detect.rb
@@ -41,5 +41,6 @@ else
     cookbook node['dcos']['ip-detect-public']['cookbook']
     source node['dcos']['ip-detect-public']['source']
     mode '0755'
+    not_if { node['dcos']['ip-detect-public']['source'].nil? }
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,6 +79,7 @@ cookbook_file '/usr/src/dcos/genconf/fault-domain-detect' do
   source node['dcos']['fault-domain-detect']['source']
   mode '0755'
   only_if { dcos_enterprise? && node['dcos']['dcos_version'].to_f >= 1.11 }
+  not_if { node['dcos']['fault-domain-detect']['source'].nil? }
 end
 
 remote_file '/usr/src/dcos/dcos_generate_config.sh' do


### PR DESCRIPTION
Support disabling script installations from cookbook by setting
the source to nil.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>