### PR TITLE
Use latest Docker cookbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - chefdk
 
 # Don't `bundle install` which takes about 1.5 mins
-install: echo "skip bundle install"
+install: echo 'skip bundle install'
 
 # Comment this, so we test everything, all the time
 # branches:
@@ -29,6 +29,7 @@ before_script:
   - chef --version
   - cookstyle --version
   - foodcritic --version
+  - gem install docker-api --version '= 1.34.0'
   - gem install zookeeper
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,13 @@ maintainer_email 'partnereng@chef.io'
 license          'Apache-2.0'
 description      'Installs/Configures Mesosphere DC/OS'
 long_description 'Installs/Configures Mesosphere DC/OS'
-version          '1.3.2'
+version          '1.3.3'
 
 source_url 'https://github.com/chef-partners/dcos-cookbook' if
   respond_to?(:source_url)
 issues_url 'https://github.com/chef-partners/dcos-cookbook/issues' if
   respond_to?(:issues_url)
-chef_version '>= 12.1' if
+chef_version '>= 12.10' if
   respond_to?(:chef_version)
 
 %w(
@@ -22,6 +22,5 @@ chef_version '>= 12.1' if
   supports distro
 end
 
-depends 'chef-yum-docker', '~> 3.0'
-depends 'docker', '~> 2.0'
-depends 'selinux', '~> 1.0.4'
+depends 'docker', '~> 4.4'
+depends 'selinux', '~> 2.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,8 +44,6 @@ package 'net-tools'
 
 group 'nogroup'
 
-include_recipe 'chef-yum-docker' if node['dcos']['manage_docker']
-
 # Install docker with overlayfs
 docker_service 'default' do
   storage_driver node['dcos']['docker_storage_driver']


### PR DESCRIPTION
Switch to the latest version of the docker and selinux cookbooks.
This is artificially version bumped to get berks to resolve it
more easily. Since this affects the compatible Chef versions, I am
going to major version bump for release.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>