### PR TITLE
Support newer DC/OS releases

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,39 +31,22 @@ module Dcos
     private
 
     def dcos_base_url
-      case node['dcos']['dcos_version']
-      when
-        '1.11.3',
-        '1.11.2',
-        '1.11.1',
-        '1.11.0',
-        '1.10.6',
-        '1.10.5',
-        '1.10.4',
-        '1.10.2',
-        '1.10.1',
-        '1.10.0',
-        '1.9.7',
-        '1.9.6',
-        '1.9.5',
-        '1.9.4',
-        '1.9.3',
-        '1.9.2',
-        '1.9.1',
-        '1.8.9'
-        return "https://downloads.mesosphere.com/dcos-enterprise/stable/#{node['dcos']['dcos_version']}" if dcos_enterprise?
-        return "https://downloads.dcos.io/dcos/stable/#{node['dcos']['dcos_version']}"
-      when 'EarlyAccess', 'earlyaccess'
-        'https://downloads.dcos.io/dcos/EarlyAccess'
+      v = node['dcos']['dcos_version']
+      return 'https://downloads.dcos.io/dcos/EarlyAccess' if v.downcase == 'earlyaccess'
+      if v.to_f >= 1.10 || v.split('.').drop(1).join('.').to_f > 9.0 || v == '1.8.9' # 1.9.0 and < 1.8.9 use else method
+        return "https://downloads.mesosphere.com/dcos-enterprise/stable/#{v}" if dcos_enterprise?
+        return "https://downloads.dcos.io/dcos/stable/#{v}"
       else # stable or older releases
-        return 'https://downloads.mesosphere.com/dcos-enterprise/stable/1.11.3' if dcos_enterprise?
+        return 'https://downloads.mesosphere.com/dcos-enterprise/stable/1.11.4' if dcos_enterprise?
         'https://downloads.dcos.io/dcos/stable'
       end
     end
 
     def dcos_commit_id
       case node['dcos']['dcos_version']
-      when 'stable', '1.11.3'
+      when 'stable', '1.11.4'
+        '8ecb7913da270b9422c9a563ce16578a355cecbb'
+      when '1.11.3'
         '96f364a598e5f06371794ebb7c40fff65d0c289f'
       when '1.11.2'
         'e871b90b33ba43478f6ba904b7289ffbf79550dd'
@@ -71,6 +54,10 @@ module Dcos
         'fefb2e4d76f397d84f450086b14eba6ca7572cd7'
       when '1.11.0'
         'b6d6ad4722600877fde2860122f870031d109da3'
+      when '1.10.8'
+        '61de47be4a8588ee5c4168ec297ad2135d5e5ed1'
+      when '1.10.7'
+        '609e7b7e06a23e85a9dfaa67fdbc52ca8b5ac95b'
       when '1.10.6'
         '2a37eea95cc4a64ede4074cc9b6d6d2844c647b0'
       when '1.10.5'
@@ -83,6 +70,12 @@ module Dcos
         'd932fc405eb80d8e5b3516eaabf2bd41a2c25c9f'
       when '1.10.0'
         'e38ab2aa282077c8eb7bf103c6fff7b0f08db1a4'
+      when '1.9.10'
+        'afa41d022b61a1b6e5723799ec6617c90621cf8a'
+      when '1.9.9'
+        'e52b4e2452970d45a39183bfd0260fb28bd920b6'
+      when '1.9.8'
+        'd1e4db6b234cd3d0b54d2be04b0b088f72870d88'
       when '1.9.7'
         '888d171dbd85d2a56cc046b95c751989ea6c7604'
       when '1.9.6'


### PR DESCRIPTION
Updates to support newer releases of DC/OS 1.9, 1.10, and 1.11

- Refactor the dcos_base_url private method to reduce update requirements
- Add 1.9.7, 1.9.8, 1.9.9, and 1.9.10 patch-levels for DC/OS 1.9
- Add 1.10.7 and 1.10.8 patch-levels for DC/OS 1.10
- Add 1.11.4 patch-level for DC/OS 1.11

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>