### PR TITLE
Simplify download URLs

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,12 +4,7 @@ module Dcos
     def dcos_generate_config_url
       return node['dcos']['dcos_generate_config_url'] if node['dcos'].key?('dcos_generate_config_url')
       return "#{dcos_base_url}/dcos_generate_config.ee.sh" if dcos_enterprise?
-      case node['dcos']['dcos_version']
-      when 'EarlyAccess', 'earlyaccess', 'stable'
-        "#{dcos_base_url}/dcos_generate_config.sh"
-      else
-        "#{dcos_base_url}/commit/#{dcos_commit_id}/dcos_generate_config.sh"
-      end
+      "#{dcos_base_url}/dcos_generate_config.sh"
     end
 
     def dcos_enterprise?
@@ -39,61 +34,6 @@ module Dcos
       else # stable or older releases
         return 'https://downloads.mesosphere.com/dcos-enterprise/stable/1.12.2' if dcos_enterprise?
         'https://downloads.dcos.io/dcos/stable'
-      end
-    end
-
-    def dcos_commit_id
-      case node['dcos']['dcos_version']
-      when '1.12.2'
-        'ed29688084953193ebb3893765f76e98d6d2533c'
-      when '1.12.1'
-        'aad01aaa24f90fd83b626acad5069e8328bbcac9'
-      when '1.12.0'
-        '6156e8f5cb2ad123aa25d116795867c49619be72'
-      when '1.11.10'
-        'b5442be7ed9bb91d26e34f17e9af39f55ff8e111'
-      when '1.11.9'
-        'c8ea1f27294953dd25bd9847d3fc7cd53784824f'
-      when '1.11.8'
-        'd319f594d2ea1102ef1cf48c33e8a24484cc89a3'
-      when '1.11.7'
-        '0bfccbeabe1423aa8fec2cc5b8d86b8948c06587'
-      when '1.11.6'
-        '521b01b736505a610bb98d715bdf847a7e8223b6'
-      when '1.11.5'
-        'b202c9098211e1ba92d2b88d17caf418d36795a5'
-      when '1.11.4'
-        '8ecb7913da270b9422c9a563ce16578a355cecbb'
-      when '1.11.3'
-        '96f364a598e5f06371794ebb7c40fff65d0c289f'
-      when '1.11.2'
-        'e871b90b33ba43478f6ba904b7289ffbf79550dd'
-      when '1.11.1'
-        'fefb2e4d76f397d84f450086b14eba6ca7572cd7'
-      when '1.11.0'
-        'b6d6ad4722600877fde2860122f870031d109da3'
-      when '1.10.11'
-        '72f5ca1cae6d4915c95f3f6e79ad8bcf9cd05db1'
-      when '1.10.10'
-        '9aac1e29a7c0acf818deaaf2d825c0402fa87060'
-      when '1.10.9'
-        '5af82595760088ed7a5296cfa91f38e030c67556'
-      when '1.10.8'
-        '61de47be4a8588ee5c4168ec297ad2135d5e5ed1'
-      when '1.10.7'
-        '609e7b7e06a23e85a9dfaa67fdbc52ca8b5ac95b'
-      when '1.10.6'
-        '2a37eea95cc4a64ede4074cc9b6d6d2844c647b0'
-      when '1.10.5'
-        '5831285e56a88d3f54446a987a0384f915832f40'
-      when '1.10.4'
-        '2d45a8f9e277a60007f277f70f01d076c913a7fe'
-      when '1.10.2'
-        '12b494a3309c65a22b7d5553debd1c053e008a31'
-      when '1.10.1'
-        'd932fc405eb80d8e5b3516eaabf2bd41a2c25c9f'
-      when '1.10.0'
-        'e38ab2aa282077c8eb7bf103c6fff7b0f08db1a4'
       end
     end
   end


### PR DESCRIPTION
After discussion with Mesosphere and dropping support for unsupported
versions of DC/OS, switch to just using the version-based URLs instead
of commit-based URLs.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>